### PR TITLE
Generate  oclif.manifest.json on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ wip.md
 .env
 
 tsconfig.tsbuildinfo
+
+oclif.manifest.json

--- a/package.json
+++ b/package.json
@@ -14,12 +14,13 @@
   "scripts": {
     "lint": "eslint -c .eslintrc.js --ext .js,.ts .",
     "test": "ts-mocha -p ./test/tsconfig.spec.json --timeout 10000 --forbid-only --file test/libs/setup.ts test/**/*.spec.ts",
-    "build": "rm -rf dist && tsc -p tsconfig.json"
+    "build": "rm -rf dist && tsc -p tsconfig.json && oclif-dev manifest"
   },
   "main": "./dist/index.js",
   "files": [
     "/dist",
-    "/bin"
+    "/bin",
+    "/oclif.manifest.json"
   ],
   "oclif": {
     "commands": "./dist/commands",


### PR DESCRIPTION
Hi, congrats on the release of the CLI!

I've played around with oclif in the past and noticed that the help output was quite slow compared to what I'm used to from the package.

The fix for this is to generate the `oclif.manifest.json` as it will pre-compile the help information.

You can test this by simply running `time ./bin/run` with and without the manifest:

Without manifest:
`Executed in  699.86 millis`

With manifest:
`Executed in  129.65 millis`